### PR TITLE
Fix for being unable to call fetch (and fetchAll etc.) with arr_params being an empty array

### DIFF
--- a/src/Docnet/DB/Statement.php
+++ b/src/Docnet/DB/Statement.php
@@ -221,7 +221,7 @@ class Statement
      */
     private function process($arr_params = NULL)
     {
-        if (NULL === $arr_params) {
+        if (NULL === $arr_params || (is_array($arr_params) && count($arr_params) == 0)) {
             if ($this->str_sql) {
                 if ($this->int_state === self::STATE_BOUND) {
                     // The NAMED parameters have already been bound to this object using bind*() methods


### PR DESCRIPTION
When trying to call ->fetch or ->fetchAll with an empty array (as $arr_params) the following warning is being displayed:
PHP Warning:  Wrong parameter count for mysqli_stmt::bind_param() in (...)/docnet/php-dbal/src/Docnet/DB/Statement.php on line 543

This is because an empty array is treated differently that a NULL, this pull request makes it behave exactly the same for both scenarios.

This is all assuming that the actual SQL string doesn't contain any binded variables (SELECT * FROM table).
This was a problem when the SQL statement is created from concatenated strings as the $arr_params was defined as an array but populated only if required.