### PR TITLE
Throw exception when executing prepared statement fails

### DIFF
--- a/src/Docnet/DB.php
+++ b/src/Docnet/DB.php
@@ -196,7 +196,7 @@ class DB
      * @param array $arr_params
      * @param String $str_result_class manually override result class (just for
      * this query)
-     * @return array|NULL
+     * @return array|null
      */
     public function fetchAll($str_sql, $arr_params = null, $str_result_class = null)
     {
@@ -210,7 +210,7 @@ class DB
      * @param array $arr_params
      * @param String $str_result_class manually override result class (just for
      * this query)
-     * @return array|NULL
+     * @return array|object|null
      */
     public function fetchOne($str_sql, $arr_params = null, $str_result_class = null)
     {
@@ -224,7 +224,7 @@ class DB
      * @param null $arr_params
      * @param String $str_result_class
      * @param int $int_fetch_mode
-     * @return array|NULL|void
+     * @return array|object|null
      */
     private function delegateFetch($str_sql, $arr_params, $str_result_class, $int_fetch_mode)
     {

--- a/src/Docnet/DB/Exception/Factory.php
+++ b/src/Docnet/DB/Exception/Factory.php
@@ -14,10 +14,9 @@ class Factory
    const CODE_MYSQL_GONE_AWAY = 2006;
 
    /**
-    * @param $strMessage
-    * @param null $intCode
-    * @throws DatabaseConnectionException
-    * @throws \Exception
+    * @param string $strMessage
+    * @param int|null $intCode
+    * @return \Exception
     */
    public static function build($strMessage, $intCode = null) {
 

--- a/src/Docnet/DB/Statement.php
+++ b/src/Docnet/DB/Statement.php
@@ -154,8 +154,8 @@ class Statement
     /**
      * Execute a query, return the first result.
      *
-     * @param Array $arr_params
-     * @return Array|NULL
+     * @param array $arr_params
+     * @return array|object|null
      */
     public function fetchOne($arr_params = NULL)
     {
@@ -165,7 +165,7 @@ class Statement
     /**
      * Execute a query, return ALL the results.
      *
-     * @param Array $arr_params
+     * @param array $arr_params
      * @return array|NULL
      */
     public function fetchAll($arr_params = NULL)

--- a/src/Docnet/DB/Statement.php
+++ b/src/Docnet/DB/Statement.php
@@ -177,7 +177,7 @@ class Statement
      * Execute an update statement
      *
      * @param array $arr_params
-     * @return array|null|object
+     * @return bool
      */
     public function update(array $arr_params = NULL)
     {
@@ -188,7 +188,7 @@ class Statement
      * Execute an insert statement
      *
      * @param array $arr_params
-     * @return array|null|object
+     * @return bool
      */
     public function insert(array $arr_params = NULL)
     {
@@ -199,7 +199,7 @@ class Statement
      * Execute a delete statement
      *
      * @param array $arr_params
-     * @return array|null|object
+     * @return bool
      */
     public function delete(array $arr_params = NULL)
     {
@@ -217,7 +217,7 @@ class Statement
      * This method used by SELECT/UPDATE/INSERT/DELETE
      *
      * @param null $arr_params
-     * @return array|null|object
+     * @return bool
      * @throws \Exception if fails to process the prepared statement
      */
     private function process($arr_params = NULL)
@@ -256,7 +256,7 @@ class Statement
         $this->int_state = self::STATE_EXECUTED;
         self::$int_execute++;
 
-        $mix_result = $this->obj_stmt->execute();
+        $bol_result = $this->obj_stmt->execute();
 
         if ($this->obj_stmt->errno != 0) {
             $str_message = sprintf(
@@ -267,7 +267,7 @@ class Statement
             throw DB\Exception\Factory::build($str_message, $this->obj_stmt->errno);
         }
 
-        return $mix_result;
+        return $bol_result;
     }
 
     /**

--- a/src/Docnet/DB/Statement.php
+++ b/src/Docnet/DB/Statement.php
@@ -218,6 +218,7 @@ class Statement
      *
      * @param null $arr_params
      * @return array|null|object
+     * @throws \Exception if fails to process the prepared statement
      */
     private function process($arr_params = NULL)
     {
@@ -254,7 +255,19 @@ class Statement
         }
         $this->int_state = self::STATE_EXECUTED;
         self::$int_execute++;
-        return $this->obj_stmt->execute();
+
+        $mix_result = $this->obj_stmt->execute();
+
+        if ($this->obj_stmt->errno != 0) {
+            $str_message = sprintf(
+                'Error processing statement - Code: %d, Message: "%s"',
+                $this->obj_stmt->errno,
+                $this->obj_stmt->error
+            );
+            throw DB\Exception\Factory::build($str_message, $this->obj_stmt->errno);
+        }
+
+        return $mix_result;
     }
 
     /**

--- a/src/Docnet/DB/Statement.php
+++ b/src/Docnet/DB/Statement.php
@@ -166,7 +166,7 @@ class Statement
      * Execute a query, return ALL the results.
      *
      * @param array $arr_params
-     * @return array|NULL
+     * @return array|null
      */
     public function fetchAll($arr_params = NULL)
     {


### PR DESCRIPTION
Main reason for this PR is to solve issues where MySQL fails to process a prepared statement because an invalid value was used. In my particular case the issue was caused by an empty string being inserted into a JSON field.

Other changes are PHPDoc updates to ensure they reflect the values actually returned by the methods.